### PR TITLE
memory: Clean up type_assignment_checks.h

### DIFF
--- a/lift/memory/allocation.h
+++ b/lift/memory/allocation.h
@@ -161,7 +161,7 @@ struct allocation : public pointer<system, T, _index_type>
     template <typename other_allocation>
     void copy(const other_allocation& other)
     {
-        memory::check_value_type_assignment_compatible<value_type, typename other_allocation::value_type>();
+        __internal::check_value_type_assignment_compatible<value_type, typename other_allocation::value_type>();
 
         resize(other.size());
 

--- a/lift/memory/type_assignment_checks.h
+++ b/lift/memory/type_assignment_checks.h
@@ -41,7 +41,7 @@
  * \file Compile-type checks for various pointer-related conditions.
  */
 namespace lift {
-namespace memory {
+namespace __internal {
 
 /**
  * Checks if a source and destination value types are assignment-compatible.
@@ -65,60 +65,5 @@ static constexpr LIFT_HOST_DEVICE bool check_value_type_assignment_compatible(vo
     return true;
 }
 
-/**
- * Check if a source and destination pointer types are assignment-compatible. Operates the
- * same as \ref check_value_type_assignment_compatible except that the input types are Lift
- * pointer types.
- */
-template <typename memptr_A, typename memptr_B>
-static constexpr LIFT_HOST_DEVICE bool check_memory_pointer_assignment_compatible(void)
-{
-    // the types must either be the same, or our type must be a const version of their type
-    static_assert(std::is_same<      typename memptr_A::value_type, typename memptr_B::value_type>::value ||
-                  std::is_same<const typename memptr_A::value_type, typename memptr_B::value_type>::value,
-                  "incompatible memory_pointer data types in assignment");
-    return true;
-}
-
-/**
- * \deprecated Assert that a Lift pointer is mutable.
- */
-template <typename memptr>
-static constexpr LIFT_HOST_DEVICE bool check_memory_pointer_mutable(void)
-{
-    static_assert(memptr::mutable_tag == 1, "pointer is immutable");
-    return true;
-}
-
-/**
- * \deprecated Assert that a Lift pointer is immutable.
- */
-template <typename memptr>
-static constexpr LIFT_HOST_DEVICE bool check_memory_pointer_immutable(void)
-{
-    static_assert(memptr::mutable_tag == 0, "pointer is mutable");
-    return true;
-}
-
-/**
- * \deprecated Assert that pointer A and pointer B are either both mutable or both immutable.
- */
-template <typename memptr_A, typename memptr_B>
-static constexpr LIFT_HOST_DEVICE bool check_memory_pointer_mutability_matches(void)
-{
-    static_assert(memptr_A::mutable_tag == memptr_B::mutable_tag, "pointer mutability mismatch");
-    return true;
-}
-
-/**
- * \deprecated Assert that pointer A and pointer B belong to the same memory space.
- */
-template <typename memptr_A, typename memptr_B>
-static constexpr LIFT_HOST_DEVICE bool check_memory_space(void)
-{
-    static_assert(target_system(memptr_A::system_tag) == target_system(memptr_B::system_tag), "pointer memory space mismatch");
-    return true;
-}
-
-} // namespace memory
+} // namespace __internal
 } // namespace lift


### PR DESCRIPTION
Remove unused code from type_assignment_checks.h Rename the 'memory'
namespace to '__internal'.

Fixes #21
