### PR TITLE
tests: Add FP comparisons to test harness

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -9,5 +9,4 @@ set(lift_test_lib_sources
     test/entrypoint.cu)
 
 cuda_add_library(liftest-lib ${lift_test_lib_sources} EXCLUDE_FROM_ALL)
-#add_dependencies(liftest-lib lift tbb)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -6,8 +6,9 @@ set(test_src
     sort.cu
     pointer.cu)
 
+
 cuda_add_executable(liftest ${liftest_src} ${test_src} EXCLUDE_FROM_ALL)
-target_link_libraries(liftest liftest-lib lift ${LINK_LIBS})
+target_link_libraries(liftest m liftest-lib lift ${LINK_LIBS})
 
 add_custom_target(lift-tests DEPENDS cpuid liftest)
 add_custom_target(lift-run-tests


### PR DESCRIPTION
Add simple FP comparisons to the test harness. Link test executables
with libm.
