### PR TITLE
Implement parallel fill

### DIFF
--- a/lift/parallel.h
+++ b/lift/parallel.h
@@ -350,6 +350,30 @@ struct parallel
                                            UniqueOutputIterator unique_keys_output,
                                            LengthOutputIterator run_lengths_output,
                                            allocation<system, uint8>& temp_storage);
+    /**
+     * Parallel fill implementation. Sets each element in range [begin, end[ to value.
+     * \tparam InputIterator    Iterator type
+     * \tparam T                Type for input data.
+     *
+     * \param begin             Iterator pointing at the first element to be processed.
+     * \param end               Iterator pointing at the end of the range to be processed.
+     * \param value             The value with which to fill the range.
+     */
+    template <typename InputIterator, typename T>
+    static inline void fill(InputIterator begin,
+                            InputIterator end,
+                            T value);
+    /**
+     * Pointer version of fill. Fills each element of vector with value
+     *
+     * \tparam T                Data type for vector.
+     *
+     * \param vector            The memory region to fill with value
+     * \param value             Value to fill each element in  vector
+     */
+    template <typename T>
+    static inline void fill(pointer<system, T>& vector,
+                            T value);
 
     /**
      * Synchronizes the compute device.

--- a/lift/parallel/parallel_cuda.inl
+++ b/lift/parallel/parallel_cuda.inl
@@ -110,6 +110,38 @@ inline void parallel<cuda>::for_each(uint32 end,
                    launch_parameters);
 }
 
+template <typename T>
+struct fill_by_reference
+{
+    T value;
+
+    fill_by_reference(T value)
+        : value(value)
+    { }
+
+    LIFT_HOST_DEVICE void operator() (T &ref)
+    {
+        ref = value;
+    }
+};
+
+template <>
+template <typename InputIterator, typename T>
+inline void parallel<cuda>::fill(InputIterator begin,
+                                 InputIterator end,
+                                 T value)
+{
+    for_each(begin, end, fill_by_reference<T>(value));
+}
+
+template <>
+template <typename T>
+inline void parallel<cuda>::fill(pointer<cuda, T>& vector,
+                                 T value)
+{
+    for_each(vector, fill_by_reference<T>(value));
+}
+
 template <>
 template <typename InputIterator, typename OutputIterator, typename Predicate>
 inline void parallel<cuda>::inclusive_scan(InputIterator first,

--- a/lift/parallel/parallel_host.inl
+++ b/lift/parallel/parallel_host.inl
@@ -95,6 +95,23 @@ inline void parallel<host>::for_each(uint32 end,
 }
 
 template <>
+template <typename InputIterator, typename T>
+inline void parallel<host>::fill(InputIterator begin,
+                                 InputIterator end,
+                                 T value)
+{
+    for_each(begin, end, fill_by_reference<T>(value));
+}
+
+template <>
+template <typename T>
+inline void parallel<host>::fill(pointer<host, T>& vector,
+                                 T value)
+{
+    for_each(vector, fill_by_reference<T>(value));
+}
+
+template <>
 template <typename InputIterator, typename OutputIterator, typename Predicate>
 inline void parallel<host>::inclusive_scan(InputIterator first,
                                            size_t len,

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3,6 +3,7 @@ target_link_libraries(cpuid lift ${LINK_LIBS})
 
 set(test_src
     pointer.cu
+    fill.cu
     sort.cu)
 
 cuda_add_executable(liftest ${liftest_src} ${test_src} EXCLUDE_FROM_ALL)

--- a/tests/fill.cu
+++ b/tests/fill.cu
@@ -1,0 +1,72 @@
+/*
+ * Lift
+ *
+ * Copyright (c) 2014-2015, NVIDIA CORPORATION
+ * Copyright (c) 2015-2016, Nuno Subtil <subtil@gmail.com>
+ * Copyright (c) 2015-2016, Roche Molecular Systems Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *    * Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *    * Neither the name of the copyright holders nor the names of its
+ *      contributors may be used to endorse or promote products derived from
+ *      this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#include <lift/test/test.h>
+#include <lift/test/check.h>
+
+#include <lift/parallel.h>
+#include <lift/backends.h>
+#include <lift/memory/scoped_allocation.h>
+
+using namespace lift;
+
+
+//Unit test for vector-wide implementation of fill
+template <target_system system>
+void fill_vector()
+{
+    uint32 size = 1000;
+    int fill_val = 10;
+
+    allocation<system, int> data(size);
+    parallel<system>::fill(data, fill_val);
+
+    for (int i = 0; i < size; i++)
+    {
+        LIFT_TEST_CHECK(data.peek(i) == fill_val)
+    }
+}
+LIFT_TEST_FUNC(fill_vector_test, fill_vector);
+
+template <target_system system>
+void fill_input_iter()
+{
+    uint32 size = 1000;
+    int fill_val = 10;
+
+    allocation<system, int> data(size);
+    parallel<system>::fill(data, fill_val);
+
+    for (int i = 0; i < size; i++)
+    {
+        LIFT_TEST_CHECK(data.peek(i) == fill_val)
+    }
+}
+LIFT_TEST_FUNC(fill_input_iter_test, fill_input_iter);


### PR DESCRIPTION
Adds a primitive that is used to fill a buffer with a constant value, along
with the appropriate unit test.

<!---
@huboard:{"custom_state":"archived"}
-->
