### PR TITLE
Remove operator() from pointer interface.

### DIFF
--- a/lift/memory/pointer.h
+++ b/lift/memory/pointer.h
@@ -392,12 +392,6 @@ struct pointer<host, T, _index_type> : public tagged_pointer_base<host, T, _inde
     {
         base::storage[pos] = value;
     }
-
-    // shortcut for peek, intended mostly for debug code
-    value_type operator() (const index_type idx) const
-    {
-        return peek(idx);
-    }
 };
 
 template <typename T,


### PR DESCRIPTION
This method was meant as a debug convenience, but can lead to a bug in code when trying to initialize. The same functionality is available via peek().
