### PR TITLE
Rename lift::swap to lift::exchange to prevent name collisions.

### DIFF
--- a/lift/util.h
+++ b/lift/util.h
@@ -39,8 +39,9 @@
 namespace lift {
 
 // swap two variables
+// use unique name so STL doesn't get confused with std version
 template <typename T>
-static inline LIFT_HOST_DEVICE void swap(T& a, T& b)
+static inline LIFT_HOST_DEVICE void exchange(T& a, T& b)
 {
     T temp;
     temp = a;


### PR DESCRIPTION
One specific case is when including lift/util.h along with lift/timer.h,
which uses <stack>. This header in gcc 5.3 (ubuntu 16.04) generates a
compiler error due to ambiguity with std::swap. The easy fix is to
change our signatiure instead of gcc's.
