### PR TITLE
Add support for copying via tagged_pointer_base.

### DIFF
--- a/lift/memory/allocation.h
+++ b/lift/memory/allocation.h
@@ -167,32 +167,10 @@ struct allocation : public pointer<system, T, _index_type>
     template <typename other_allocation>
     void copy(const other_allocation& other)
     {
-        __internal::check_value_type_assignment_compatible<value_type, typename other_allocation::value_type>();
-
         resize(other.size());
 
-        if (system == cuda)
-        {
-            // copying to GPU...
-            if (target_system(other_allocation::system_tag) == cuda)
-            {
-                // ... from the GPU
-                cudaMemcpy((void *) base::data(), other.data(), sizeof(value_type) * other.size(), cudaMemcpyDeviceToDevice);
-            } else {
-                // ... from the host
-                cudaMemcpy((void *) base::data(), other.data(), sizeof(value_type) * other.size(), cudaMemcpyHostToDevice);
-            }
-        } else {
-            // copying to host...
-            if (target_system(other_allocation::system_tag) == cuda)
-            {
-                // ... from the GPU
-                cudaMemcpy((void *) base::data(), other.data(), sizeof(value_type) * other.size(), cudaMemcpyDeviceToHost);
-            } else {
-                // ... from the host
-                memcpy((void *) base::data(), other.data(), sizeof(value_type) * other.size());
-            }
-        }
+        // call tagged_pointer_base version.
+        base::copy(other);
     }
 
     // cross-memory-space copy from raw pointer


### PR DESCRIPTION
The bulk of allocation::copy() has been moved down into tagged_pointer_base
except for the resizing aspect. The destination is required to be at least as
big as the source data. This allows for range-based copies (sub copies).
