### PR TITLE
Minor enhancement that keeps from reallocating memory.

### DIFF
--- a/lift/memory/allocation.h
+++ b/lift/memory/allocation.h
@@ -133,6 +133,9 @@ struct allocation : public pointer<system, T, _index_type>
 
     virtual void resize(size_type count)
     {
+        // no-op if the size is the same
+        if (storage_size == count) return;
+
         size_type old_storage_size;
         pointer_type old_storage;
 


### PR DESCRIPTION
Don't reallocate memory if the target size is the same as the existing size.
