### PR TITLE
Remove ability to call pointer::copy() in device code.

### DIFF
--- a/lift/memory/pointer.h
+++ b/lift/memory/pointer.h
@@ -140,7 +140,7 @@ struct tagged_pointer_base
     // cross-memory-space copy from another pointer
     // note that this does not handle copies across different GPUs
     template <target_system other_system, typename other_value_type>
-    LIFT_HOST_DEVICE void copy(const tagged_pointer_base<other_system, other_value_type, index_type>& other)
+    void copy(const tagged_pointer_base<other_system, other_value_type, index_type>& other)
     {
         __internal::check_value_type_assignment_compatible<value_type, other_value_type>();
 


### PR DESCRIPTION
This comes about as a warning in gcc 5.3.1 and isn't allowed in device code anyway.
